### PR TITLE
add 'this' to possible forbidden keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Description
 -----------
 
 This [CoffeeLint](http://www.coffeelint.org/) rule forbids the usage of a specified subset of
-the following keywords: `if`, `unless`, `while`, `loop`, `until`, `true`, `yes`, `on`, `false`,
+the following keywords: `this`, `if`, `unless`, `while`, `loop`, `until`, `true`, `yes`, `on`, `false`,
 `no`, `off`, `is`, `==`, `isnt`, `!=`, `!`, `not`, `&&`, `and`, `||`, `or`, `++`, `--`, `..`, and
 `...`
 

--- a/index.coffee
+++ b/index.coffee
@@ -9,7 +9,6 @@ module.exports = class ForbiddenKeywords
       'on': 'true'
       'off': 'false'
       # Some other reasonable replacements:
-      # 'this': '@'
       # 'is': '=='
       # 'isnt': '!='
       # 'unless': 'if not'

--- a/index.coffee
+++ b/index.coffee
@@ -9,6 +9,7 @@ module.exports = class ForbiddenKeywords
       'on': 'true'
       'off': 'false'
       # Some other reasonable replacements:
+      # 'this': '@'
       # 'is': '=='
       # 'isnt': '!='
       # 'unless': 'if not'
@@ -19,14 +20,14 @@ module.exports = class ForbiddenKeywords
       # '--': '-=1'
     description: '''
       This rule forbids the usage of a specified subset of the following keywords:
-        if, unless, while, loop, until, true, yes, on, false, no, off,
+        this, if, unless, while, loop, until, true, yes, on, false, no, off,
         is, ==, isnt, !=, !, not, &&, and, ||, or, ++, --, .., ...
       By default, ['yes', 'no', 'on', 'off'] are forbidden.
       '''
 
   tokens: [
-    'IF', 'LOOP', 'UNTIL', 'BOOL', 'UNARY', 'UNARY_MATH', 'COMPARE', 'LOGIC', 'LOOP', '++', '--',
-    '..', '...'
+    'THIS', 'IF', 'LOOP', 'UNTIL', 'BOOL', 'UNARY', 'UNARY_MATH', 'COMPARE',
+    'LOGIC', 'LOOP', '++', '--', '..', '...'
   ]
 
   lintToken: (token, tokenApi) ->


### PR DESCRIPTION
I want to ensure that '@' is always used instead of 'this' in my coffeescript code. This pull request allows that.