### PR TITLE
coffee-script is a real dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "coffeelint": ">=1.4"
   },
-  "devDependencies": {
-    "coffee-script": "~1.7.0"
+  "dependencies": {
+    "coffee-script": "^1.7.0"
   }
 }


### PR DESCRIPTION
It's depended on at runtime for coffee-script/register.

On node v4 (npm v2), if you don't have coffee-script as a devDependency
in your package (only coffeelint), this module will die because it won't
see the copy of coffee-script underneath coffeelint.

Upgraded the version pattern while we're at it.